### PR TITLE
Modified BCD class to be used as a computation class

### DIFF
--- a/concord_ml/bcd/computations.py
+++ b/concord_ml/bcd/computations.py
@@ -31,7 +31,7 @@ class BayesianChangepointDetection(Computation):
 
     def process_record(self, ctx, record):
         """ Sends most probable run length to all ostreams.
-        
+
             Args:
                 record (Dict[str, str]): record.key contains isoformat
                     timestamp associated with record.data.

--- a/concord_ml/bcd/computations.py
+++ b/concord_ml/bcd/computations.py
@@ -30,10 +30,8 @@ class BayesianChangepointDetection(Computation):
         self.present = dt.date.min.isoformat()  # init w/ earliest date
 
     def process_record(self, ctx, record):
-        """ Sends A 1-D np.array of floats representing the probability
-            distribution of the current run length to all ostreams.
-            Output[r_0] is the probability that r=r_0 at time r_0.
-
+        """ Sends most probable run length to all ostreams.
+        
             Args:
                 record (Dict[str, str]): record.key contains isoformat
                     timestamp associated with record.data.
@@ -47,7 +45,7 @@ class BayesianChangepointDetection(Computation):
             result = self.step(float(record.data))
             if self.ostream is not None:
                 for stream in self.ostream:
-                    ctx.produce_record(stream, '~', result)
+                    ctx.produce_record(stream, '~', str(result.argmax()))
 
     def metadata(self):
         return Metadata(

--- a/tests/test_bcd.py
+++ b/tests/test_bcd.py
@@ -18,7 +18,8 @@ def test_bcd_against_reference(hazard):
     data = [0] * 100 + [2] * 100
     istreams = []
     ostreams = []
-    detector = BayesianChangepointDetection(hazard, Gaussian(0.1, 0.1, 1, 1), istreams, ostreams)
+    detector = BayesianChangepointDetection(hazard, Gaussian(0.1, 0.1, 1, 1),
+                                            istreams, ostreams)
 
     reference = offline_changepoint_detection(data,
                                               hazard, Gaussian(0.1, 0.1, 1, 1))

--- a/tests/test_bcd.py
+++ b/tests/test_bcd.py
@@ -16,7 +16,9 @@ def hazard():
 
 def test_bcd_against_reference(hazard):
     data = [0] * 100 + [2] * 100
-    detector = BayesianChangepointDetection(hazard, Gaussian(0.1, 0.1, 1, 1))
+    istreams = []
+    ostreams = []
+    detector = BayesianChangepointDetection(hazard, Gaussian(0.1, 0.1, 1, 1), istreams, ostreams)
 
     reference = offline_changepoint_detection(data,
                                               hazard, Gaussian(0.1, 0.1, 1, 1))


### PR DESCRIPTION
Major changes:
    - BayesianChangepointDetection now extends Computation
    - Constructor takes istream and ostream arguments
    - Class will function as a computation, reading from istreams and
      producing the run-length probability array to ostreams
Note: end user will still have to manually call serve_computation, and provide
their own hazard and distribution.
